### PR TITLE
Improve help messages

### DIFF
--- a/src/mafia-bot.ts
+++ b/src/mafia-bot.ts
@@ -5,6 +5,9 @@ import {
     DEFAULT_MAFIA_COUNT,
     GAME_STATUS,
     MESSAGES,
+    START_HINT,
+    HELP_TEXT,
+    OWNER_HELP_TEXT,
     ROLES,
     Role,
     GameStatus,
@@ -56,7 +59,19 @@ const endGame = (game: Game, winner: string) => {
 };
 
 bot.onText(/\/start$/, msg => {
-    bot.sendMessage(msg.chat.id, `🎭 Welcome to Mafia Game Bot!\n\nCommands:\n/creategame [numPlayers] - Create a game with optional player count\n/joingame [gameId] - Join a game\n/startgame - Assign roles and start (owner only)\n/dashboard - Reveal roles & manage game (owner only)`);
+    bot.sendMessage(msg.chat.id, START_HINT);
+});
+
+bot.onText(/\/help$/, msg => {
+    const userId = msg.from?.id;
+    bot.sendMessage(msg.chat.id, HELP_TEXT);
+    if (!userId) return;
+    const existingGameId = userGames.get(userId);
+    if (!existingGameId) return;
+    const game = games.get(existingGameId);
+    if (game?.ownerId === userId) {
+        bot.sendMessage(msg.chat.id, OWNER_HELP_TEXT);
+    }
 });
 
 bot.onText(/\/abortgame$/, (msg) => {
@@ -101,6 +116,7 @@ bot.onText(/\/creategame(?:\s+(\d+)\s+(\d+))?$/, (msg, match) => {
     bot.sendMessage(msg.chat.id, `🎮 Game created! Game ID: ${gameId}\nMax Players: ${maxPlayers}\nMax Mafia: ${maxMafia}\nJoin link: ${joinLink}`, {
         reply_markup: { inline_keyboard: [[{ text: 'Join Game', url: joinLink }]] }
     });
+    bot.sendMessage(msg.chat.id, OWNER_HELP_TEXT);
 });
 
 const handleJoin = (msg: TelegramBot.Message, match:RegExpExecArray | null) => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -26,6 +26,24 @@ export const MESSAGES = {
   NOT_AUTHORIZED_CHAT: '❌ Not authorized!',
 };
 
+export const START_HINT =
+  'Welcome to Mafia Game Bot! Send /help for commands and game rules.';
+
+export const HELP_TEXT =
+  '📖 Commands:\n' +
+  '/creategame [players] [mafia] - create a new game (defaults 11 players, 3 mafia). You become the owner.\n' +
+  '/joingame <gameId> - join an existing game or use a join link.\n' +
+  '\nWhen enough players join, open /dashboard to begin. Roles are sent when the game starts.\n' +
+  'Mafia eliminate others while civilians try to expose them.';
+
+export const OWNER_HELP_TEXT =
+  '\n<b>Owner Tips</b>\n' +
+  'Single command to manage whole game:\n/dashboard\n' +
+  '\nAdvanced commands:\n' +
+  '/startgame - start the game manually\n' +
+  '/abortgame - cancel your current game';
+
+
 export interface Player {
   id: number;
   name: string;


### PR DESCRIPTION
## Summary
- refine `/start` hint with join info
- add owner-specific help text and show it when appropriate
- expand help with defaults and instructions
- clarify `/creategame` follow-up message

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68470d836d208329b413b0bc659ee47d