### PR TITLE
Add CI workflow and deployment instructions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm run build
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Mafia Bot
+
+This project is a small Telegram bot implemented in TypeScript.
+
+The bot requires two environment variables:
+
+- `BOT_TOKEN` – the bot API token from BotFather.
+- `BOT_USERNAME` – the bot's username without the `@` sign.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm ci
+```
+
+2. Create a `.env` file in the project root:
+
+```bash
+BOT_TOKEN=your-telegram-token
+BOT_USERNAME=your-bot-username
+```
+
+## Development
+
+Run the bot with `ts-node`:
+
+```bash
+npm run dev
+```
+
+## Building
+
+Compile the sources and start the bot:
+
+```bash
+npm run build
+npm start
+```
+
+The repository also includes a GitHub Actions workflow in `.github/workflows/node.yml` that installs dependencies and builds the project on each push to `main`.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the bot
- document environment variables and deployment guidelines in README
- streamline README instructions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847530edbfc83298873c91f1fb66f25