### PR TITLE
Add start step to workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -19,4 +19,8 @@ jobs:
         env:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
+      - run: npm start
+        env:
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
 


### PR DESCRIPTION
## Summary
- start the bot after building in CI workflow

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6848362534788329ad907d0d9e7a0b3b